### PR TITLE
74 reject claim template suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,14 +66,23 @@ The username is already provided with `user1`, the respective password is `test`
 ## SpecificClaim Flow 
 
 ### Without referencing an attachment:
-`flow start CreateSpecificClaim name: SpecificClaim, supervisoryAuthority: Supervisory Authority, claimTemplateLinearId: <ClaimTemplateLinearId>, supportingClaimsLinearIds: []`
+`flow start CreateSpecificClaim name: SpecificClaim, supervisoryAuthority: Supervisory Authority, auditor: Auditor, claimTemplateLinearId: <ClaimTemplateLinearId>, supportingClaimsLinearIds: []`
 
 `run vaultQuery contractStateType: com.compliance.states.SpecificClaim`
 
 ### With referencing an attachment:
-`flow start CreateSpecificClaim name: SpecificClaim, supervisoryAuthority: Supervisory Authority, claimTemplateLinearId: <ClaimTemplateLinearId>, supportingClaimsLinearIds: [], attachmentID: <attachmentID>`
+`flow start CreateSpecificClaim name: SpecificClaim, supervisoryAuthority: Supervisory Authority, auditor: Auditor, claimTemplateLinearId: <ClaimTemplateLinearId>, supportingClaimsLinearIds: [], attachmentID: <attachmentID>`
 
 `run vaultQuery contractStateType: com.compliance.states.SpecificClaim`
+
+## UpdateSpecificClaim Flow
+
+### Without referencing an attachment:
+`flow start UpdateSpecificClaim specificClaimLinearId: <linearID>, name: SpecificClaim, supervisoryAuthority: Supervisory Authority, auditor: Auditor, claimTemplateLinearId: <ClaimTemplateLinearId>, supportingClaimsLinearIds: []`
+
+### With referencing an attachment:
+`flow start UpdateSpecificClaim specificClaimLinearId: <linearID>, name: SpecificClaim, supervisoryAuthority: Supervisory Authority, auditor: Auditor, claimTemplateLinearId: <ClaimTemplateLinearId>, supportingClaimsLinearIds: [], attachmentID: <attachmentID>`
+
 
 
 # Handling Attachments

--- a/contracts/src/main/java/com/compliance/contracts/ClaimTemplateContract.java
+++ b/contracts/src/main/java/com/compliance/contracts/ClaimTemplateContract.java
@@ -57,6 +57,10 @@ public class ClaimTemplateContract implements Contract {
             requireThat(require -> {
                 return null;
             });
+        } else if (commandData instanceof Commands.RejectClaimTemplateSuggestion) {
+            requireThat(require -> {
+                return null;
+            });
         }
     }
 
@@ -70,6 +74,9 @@ public class ClaimTemplateContract implements Contract {
 
         }
         class AcceptClaimTemplateSuggestion implements Commands{
+
+        }
+        class RejectClaimTemplateSuggestion implements Commands{
 
         }
     }

--- a/contracts/src/main/java/com/compliance/states/SpecificClaim.java
+++ b/contracts/src/main/java/com/compliance/states/SpecificClaim.java
@@ -33,6 +33,9 @@ public class SpecificClaim implements LinearState {
     private final Party financialServiceProvider;
     @NotNull
     private final Party supervisoryAuthority;
+
+    @NotNull
+    private final Party auditor;
     private final List<AbstractParty> participants;
 
     // A reference to the claim template that is implemented by this specific claim.
@@ -48,9 +51,11 @@ public class SpecificClaim implements LinearState {
                          String description,
                          @NotNull Party financialServiceProvider,
                          @NotNull Party supervisoryAuthority,
+                         Party auditor,
                          LinearPointer<ClaimTemplate> claimTemplate,
                          List<LinearPointer<SpecificClaim>> supportingClaims) {
         this.name = name;
+        this.auditor = auditor;
         this.linearId = linearId;
         this.description = description;
         this.claimTemplate = claimTemplate;
@@ -69,10 +74,12 @@ public class SpecificClaim implements LinearState {
                          String description,
                          @NotNull Party financialServiceProvider,
                          @NotNull Party supervisoryAuthority,
+                         Party auditor,
                          LinearPointer<ClaimTemplate> claimTemplate,
                          List<LinearPointer<SpecificClaim>> supportingClaims,
                          SecureHash attachmentID) {
         this.name = name;
+        this.auditor = auditor;
         this.linearId = linearId;
         this.description = description;
         this.attachmentID = attachmentID;
@@ -127,4 +134,6 @@ public class SpecificClaim implements LinearState {
     public String getDescription() {
         return description;
     }
+
+    public Party getAuditor(){return auditor;}
 }

--- a/workflows/src/main/java/com/compliance/flows/CreateSpecificClaim.java
+++ b/workflows/src/main/java/com/compliance/flows/CreateSpecificClaim.java
@@ -25,24 +25,25 @@ public class CreateSpecificClaim {
     public static class CreateSpecificClaimInitiator extends FlowLogic<SignedTransaction> {
 
         private final String name;
-        private SecureHash attachmentID;
 
+        private final Party auditor;
+        private SecureHash attachmentID;
         private final String description;
         private final Party supervisoryAuthority;
-
         private final UniqueIdentifier claimTemplateLinearId;
-
         private final List<UniqueIdentifier> supportingClaimsLinearIds;
 
         public CreateSpecificClaimInitiator(
                 String name,
                 String description,
                 Party supervisoryAuthority,
+                Party auditor,
                 UniqueIdentifier claimTemplateLinearId,
                 List<UniqueIdentifier> supportingClaimsLinearIds
         ) {
             this.name = name;
             this.description = description;
+            this.auditor = auditor;
             this.supervisoryAuthority = supervisoryAuthority;
             this.claimTemplateLinearId = claimTemplateLinearId;
             this.supportingClaimsLinearIds = supportingClaimsLinearIds;
@@ -52,6 +53,7 @@ public class CreateSpecificClaim {
                 String name,
                 String description,
                 Party supervisoryAuthority,
+                Party auditor,
                 UniqueIdentifier claimTemplateLinearId,
                 List<UniqueIdentifier> supportingClaimsLinearIds,
                 SecureHash attachmentID
@@ -59,6 +61,7 @@ public class CreateSpecificClaim {
             this.name = name;
             this.description = description;
             this.attachmentID = attachmentID;
+            this.auditor = auditor;
             this.supervisoryAuthority = supervisoryAuthority;
             this.claimTemplateLinearId = claimTemplateLinearId;
             this.supportingClaimsLinearIds = supportingClaimsLinearIds;
@@ -79,6 +82,7 @@ public class CreateSpecificClaim {
                         this.description,
                         this.getOurIdentity(),
                         this.supervisoryAuthority,
+                        this.auditor,
                         new LinearPointer<>(claimTemplateLinearId, ClaimTemplate.class),
                         this.supportingClaimsLinearIds.stream().map(claimLinearId -> new LinearPointer<>(claimLinearId, SpecificClaim.class)).collect(Collectors.toList()),
                         this.attachmentID
@@ -95,6 +99,7 @@ public class CreateSpecificClaim {
                         this.description,
                         this.getOurIdentity(),
                         this.supervisoryAuthority,
+                        this.auditor,
                         new LinearPointer<>(claimTemplateLinearId, ClaimTemplate.class),
                         this.supportingClaimsLinearIds.stream().map(claimLinearId -> new LinearPointer<>(claimLinearId, SpecificClaim.class)).collect(Collectors.toList())
                 );

--- a/workflows/src/main/java/com/compliance/flows/RejectClaimTemplateSuggestion.java
+++ b/workflows/src/main/java/com/compliance/flows/RejectClaimTemplateSuggestion.java
@@ -1,0 +1,115 @@
+package com.compliance.flows;
+
+import co.paralleluniverse.fibers.Suspendable;
+import com.compliance.contracts.ClaimTemplateContract;
+import com.compliance.states.ClaimTemplateSuggestion;
+import net.corda.core.contracts.StateAndRef;
+import net.corda.core.contracts.UniqueIdentifier;
+import net.corda.core.flows.*;
+import net.corda.core.identity.Party;
+import net.corda.core.node.NodeInfo;
+import net.corda.core.node.services.Vault;
+import net.corda.core.node.services.vault.QueryCriteria;
+import net.corda.core.transactions.SignedTransaction;
+import net.corda.core.transactions.TransactionBuilder;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class RejectClaimTemplateSuggestion {
+
+    @InitiatingFlow
+    @StartableByRPC
+    public static class RejectClaimTemplateSuggestionInitiator extends FlowLogic<SignedTransaction> {
+
+        @NotNull
+        private final UniqueIdentifier linearId;
+
+        public RejectClaimTemplateSuggestionInitiator(@NotNull UniqueIdentifier linearId) {
+            this.linearId = linearId;
+        }
+
+        @Override
+        @Suspendable
+        public SignedTransaction call() throws FlowException {
+
+            final Party notary = getServiceHub().getNetworkMapCache().getNotaryIdentities().get(0);
+            final TransactionBuilder builder = new TransactionBuilder(notary);
+            try {
+                QueryCriteria inputCriteria = new QueryCriteria.LinearStateQueryCriteria()
+                        .withUuid(Collections.singletonList(UUID.fromString(linearId.toString())))
+                        .withStatus(Vault.StateStatus.UNCONSUMED)
+                        .withRelevancyStatus(Vault.RelevancyStatus.RELEVANT);
+
+                final StateAndRef<ClaimTemplateSuggestion> input = getServiceHub().getVaultService().queryBy(ClaimTemplateSuggestion.class, inputCriteria).getStates().get(0);
+                builder.addInputState(input);
+
+                // Add all parties in the network
+                final List<Party> involvedParties = getServiceHub().getNetworkMapCache().getAllNodes().stream().map(NodeInfo::getLegalIdentities).collect(Collectors.toList()).stream().flatMap(List::stream).collect(Collectors.toList());
+
+                // Remove yourself
+                involvedParties.remove(getOurIdentity());
+                // Remove notaries
+                involvedParties.removeAll(getServiceHub().getNetworkMapCache().getNotaryIdentities());
+
+                builder.addCommand(new ClaimTemplateContract.Commands.RejectClaimTemplateSuggestion(),
+                        involvedParties.stream().map(Party::getOwningKey).collect(Collectors.toList())
+                );
+
+                // Verify that the transaction is valid.
+                builder.verify(getServiceHub());
+
+                final SignedTransaction signedTransaction = getServiceHub().signInitialTransaction(builder);
+
+                involvedParties.remove(getOurIdentity());
+
+                List<FlowSession> sessions = involvedParties.stream().map(this::initiateFlow).collect(Collectors.toList());
+
+                SignedTransaction stx = subFlow(new CollectSignaturesFlow(signedTransaction, sessions));
+
+                return subFlow(new FinalityFlow(stx, sessions));
+            }
+
+            catch (IndexOutOfBoundsException e) {
+                throw new FlowException("ERROR: No ClaimTemplateSuggestion with provided ID found!");
+            }
+
+        }
+    }
+
+    @InitiatedBy(RejectClaimTemplateSuggestion.RejectClaimTemplateSuggestionInitiator.class)
+    public static class RejectClaimTemplateSuggestionResponder extends FlowLogic<Void> {
+        //private variable
+        private final FlowSession counterpartySession;
+
+        //Constructor
+        public RejectClaimTemplateSuggestionResponder(FlowSession counterpartySession) {
+            this.counterpartySession = counterpartySession;
+        }
+
+        @Suspendable
+        @Override
+        public Void call() throws FlowException {
+            SignedTransaction signedTransaction = subFlow(new SignTransactionFlow(counterpartySession) {
+                @Suspendable
+                @Override
+                protected void checkTransaction(SignedTransaction stx) {
+                    /*
+                     * SignTransactionFlow will automatically verify the transaction and its signatures before signing it.
+                     * However, just because a transaction is contractually valid doesn’t mean we necessarily want to sign.
+                     * What if we don’t want to deal with the counterparty in question, or the value is too high,
+                     * or we’re not happy with the transaction’s structure? checkTransaction
+                     * allows us to define these additional checks. If any of these conditions are not met,
+                     * we will not sign the transaction - even if the transaction and its signatures are contractually valid.
+                     * */
+                }
+            });
+            // Stored the transaction into database.
+            subFlow(new ReceiveFinalityFlow(counterpartySession, signedTransaction.getId()));
+            return null;
+        }
+    }
+
+
+}

--- a/workflows/src/main/java/com/compliance/flows/UpdateSpecificClaim.java
+++ b/workflows/src/main/java/com/compliance/flows/UpdateSpecificClaim.java
@@ -28,6 +28,7 @@ public class UpdateSpecificClaim {
         // Name of the SpecificClaim
         private final String name;
 
+        private final Party auditor;
         private SecureHash attachmentID;
         @NotNull
         private final UniqueIdentifier specificClaimLinearId;
@@ -46,11 +47,30 @@ public class UpdateSpecificClaim {
                 String name,
                 String description,
                 Party supervisoryAuthority,
+                Party auditor,
+                UniqueIdentifier claimTemplateLinearId,
+                List<UniqueIdentifier> supportingClaimsLinearIds
+        ) {
+            this.name = name;
+            this.auditor = auditor;
+            this.specificClaimLinearId = specificClaimLinearId;
+            this.description = description;
+            this.supervisoryAuthority = supervisoryAuthority;
+            this.claimTemplateLinearId = claimTemplateLinearId;
+            this.supportingClaimsLinearIds = supportingClaimsLinearIds;
+        }
+        public UpdateSpecificClaimInitiator(
+                @NotNull UniqueIdentifier specificClaimLinearId,
+                String name,
+                String description,
+                Party supervisoryAuthority,
+                Party auditor,
                 UniqueIdentifier claimTemplateLinearId,
                 List<UniqueIdentifier> supportingClaimsLinearIds,
                 SecureHash attachmentID
         ) {
             this.name = name;
+            this.auditor = auditor;
             this.specificClaimLinearId = specificClaimLinearId;
             this.description = description;
             this.supervisoryAuthority = supervisoryAuthority;
@@ -89,6 +109,7 @@ public class UpdateSpecificClaim {
                         this.description,
                         this.getOurIdentity(),
                         this.supervisoryAuthority,
+                        this.auditor,
                         new LinearPointer<>(claimTemplateLinearId, ClaimTemplate.class),
                         this.supportingClaimsLinearIds
                                 .stream()
@@ -109,6 +130,7 @@ public class UpdateSpecificClaim {
                         this.description,
                         this.getOurIdentity(),
                         this.supervisoryAuthority,
+                        this.auditor,
                         new LinearPointer<>(claimTemplateLinearId, ClaimTemplate.class),
                         this.supportingClaimsLinearIds
                                 .stream()


### PR DESCRIPTION
Added RejectClaimTemplateSuggestion Flow. Using this flow would make a ClaimTemplateSuggestion CONSUMED und thus not usable anymore. It seemed to me that adding a new variable to the ClaimTemplateSuggestion like "status" or "isRejected" would add unnecessary complexity to the process.